### PR TITLE
Add user student and pwd ssh login to ansible

### DIFF
--- a/images/ansible.pkr.hcl
+++ b/images/ansible.pkr.hcl
@@ -22,4 +22,16 @@ build {
             "sudo dnf install -y ansible",
         ]
     }
+
+    provisioner "file" {
+        source = "ansible/inventory"
+        destination = "/tmp/inventory"
+    }
+
+    provisioner "ansible" {
+        playbook_file = "./ansible/ansible-setup.yml"
+        user = "rhel"
+        extra_arguments = [ "-vvvv" ]
+    }
+
 }

--- a/images/ansible/ansible-setup.yml
+++ b/images/ansible/ansible-setup.yml
@@ -1,0 +1,26 @@
+---
+- name: configures ansible node
+  hosts: all
+  become: true
+
+  tasks:
+
+    - name: Install useful packages
+      include_tasks: "./roles/control_node/tasks/package_dependencies.yml"
+
+    - name: Install oasis roles collection
+      command: "ansible-galaxy collection install oasis_roles.system"
+
+    - name: Add user 'student'
+      ansible.builtin.user:
+        name: student
+        shell: /bin/bash
+        password: "{{ 'ansible123!' | password_hash('sha512', 'mysecretsalt') }}"
+        groups: wheel
+        append: yes
+
+    - name: Change SSHD to allow password logins
+      import_role:
+        name: oasis_roles.system.sshd
+      vars:
+        sshd_allow_password_login: yes


### PR DESCRIPTION
This modifies the ansible image:

- add a user called student with password and part of the group wheel
- configure sshd so that pwd based login is possible
