### PR TITLE
Gha on every pr

### DIFF
--- a/.github/workflows/instruqt-track-test.yml
+++ b/.github/workflows/instruqt-track-test.yml
@@ -9,13 +9,7 @@ on:
   # changes in ansible-core or ansible-test
   schedule:
     - cron: '0 6 * * *'
-on: 
   workflow_dispatch:
-  push:
-    paths:
-      - 'tracks/*'
-    branches:
-      - devel
 
 jobs:
   instruqt-track-test:

--- a/.github/workflows/instruqt-track-test.yml
+++ b/.github/workflows/instruqt-track-test.yml
@@ -1,4 +1,14 @@
 name: instruqt-track-test
+on:
+  # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+  pull_request:
+  # Run CI once per day (at 06:00 UTC)
+  # This ensures that even if there haven't been commits that we are still
+  # testing. This is particularly important to validate the scenarios against
+  # changes in ansible-core or ansible-test
+  schedule:
+    - cron: '0 6 * * *'
 on: 
   workflow_dispatch:
   push:
@@ -12,13 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: install ansible
         run: sudo apt-get install ansible
+
       - name: run playbook
         run: ansible-playbook /home/runner/work/instruqt/instruqt/.github/workflows/ansible/instruqt-track-test.yml
         env:
           INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_API_KEY }}
       - name: 'Upload Artifact'
+
         uses: actions/upload-artifact@v2
         with:
           path: /tmp/test-*


### PR DESCRIPTION
1. Ensure CI is run on every PR
Previously it was only run manually

2. Run CI once per day (at 06:00 UTC)

This ensures that even if there haven't been commits that we are still testing. This is particularly important to validate the scenarios against changes in ansible-core or ansible-test
