### PR TITLE
adding extra-vars to import build secrets

### DIFF
--- a/images/ansible.pkr.hcl
+++ b/images/ansible.pkr.hcl
@@ -19,6 +19,6 @@ build {
     provisioner "ansible" {
         playbook_file = "./ansible/ansible-setup.yml"
         user = "rhel"
-        extra_arguments = [ "-vvvv" ]
+        extra_arguments = [ "-e", "@ansible/extra-vars.yml" ]
     }
 }

--- a/images/ansible/ansible-setup.yml
+++ b/images/ansible/ansible-setup.yml
@@ -73,10 +73,10 @@
         name: sshd
         state: restarted
 
-    - name: DNF update the system
-      dnf:
-        name:  "*"
-        state: latest
+    # - name: DNF update the system
+    #   dnf:
+    #     name:  "*"
+    #     state: latest
 
     - name: create repo
       yum_repository:

--- a/images/ansible/controller-setup.yml
+++ b/images/ansible/controller-setup.yml
@@ -72,6 +72,29 @@
       include_role:
         name: ansible.workshops.code_server
 
+    - name: disable dnf automatic services
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: stopped
+      loop:
+        - dnf-automatic.timer
+
+    - name: automatic.conf disable downloads
+      ansible.builtin.lineinfile:
+        path: /etc/dnf/automatic.conf
+        regexp: '^download_updates'
+        line: download_updates = no
+
+    - name: automatic.conf disable updates
+      ansible.builtin.lineinfile:
+        path: /etc/dnf/automatic.conf
+        regexp: '^apply_updates'
+        line: apply_updates = no
+
+    - name: Disable RHUI repos
+      ansible.builtin.command: >
+        dnf config-manager --set-disabled rhui*
+
     - name: copy setup-scripts to tower node
       copy:
         src: ./setup-scripts

--- a/images/ansible/extra-vars.yml
+++ b/images/ansible/extra-vars.yml
@@ -1,0 +1,4 @@
+---
+offline_token: "{{ lookup('env','REDHAT_OFFLINE_TOKEN') }}"
+your_username: "{{ lookup('env','REDHAT_USERNAME') }}"
+your_password: "{{ lookup('env','REDHAT_PASSWORD') }}"

--- a/images/automation-controller.pkr.hcl
+++ b/images/automation-controller.pkr.hcl
@@ -29,7 +29,7 @@ build {
     provisioner "ansible" {
       playbook_file = "./ansible/controller-setup.yml"
       user = "rhel"
-      extra_arguments = [ "-vvvv" ]
+      extra_arguments = [ "-e", "@ansible/extra-vars.yml" ]
     }
 
 }


### PR DESCRIPTION
We need to a good way of importing secrets to automate builds. Moved, I think, all of what we need to build images into an extra-vars file within the image packer files. 

Image builds are succeeding atm with these changes. @IPvSean @anshulbehl @craig-br 