### PR TITLE
Default to Python3 during Packer Ansible provisioning. Allow additional Ansible args

### DIFF
--- a/images/ansible.pkr.hcl
+++ b/images/ansible.pkr.hcl
@@ -3,23 +3,35 @@ variable "project_id" {
     default = "red-hat-mbu"
 }
 
-source "googlecompute" "ansible" {
-    project_id          = var.project_id
-    # source_image_family = "rhel-8"
-    source_image        = "rhel8"
-    ssh_username        = "rhel"
-    zone                = "us-east1-d"
-    machine_type        = "n1-standard-2"
-    image_name          = "ansible"
+variable "zone" {
+    type    = string
+    default = "us-east1-d"
 }
 
+variable "image_name" {
+    type    = string
+    default = "ansible"
+}
+
+variable "ansible_extra_args" {
+    type    = string
+    default = ""
+}
+
+source "googlecompute" "ansible" {
+    project_id          = var.project_id
+    source_image        = "rhel8"
+    ssh_username        = "rhel"
+    zone                = var.zone
+    machine_type        = "n1-standard-2"
+    image_name          = var.image_name
+}
 
 build {
     sources = ["sources.googlecompute.ansible"]
-
     provisioner "ansible" {
         playbook_file = "images/ansible/ansible-setup.yml"
         user = "rhel"
-        extra_arguments = [ "-e", "@images/ansible/extra-vars.yml" ]
+        extra_arguments = ["-e", "@images/ansible/extra-vars.yml", "-e", "ansible_python_interpreter=/usr/bin/python3", var.ansible_extra_args]
     }
 }

--- a/images/automation-controller.pkr.hcl
+++ b/images/automation-controller.pkr.hcl
@@ -13,6 +13,11 @@ variable "image_name" {
     default = "automation-controller"
 }
 
+variable "ansible_extra_args" {
+    type    = string
+    default = ""
+}
+
 source "googlecompute" "automation-controller" {
     project_id          = var.project_id
     source_image_family = "rhel-8"
@@ -32,7 +37,7 @@ build {
       playbook_file = "images/ansible/workshop-collection-install.yml"
       user = "rhel"
       inventory_file_template = "controller ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }}\n"
-      extra_arguments = [ "-e", "@images/ansible/extra-vars.yml" ]
+      extra_arguments = ["-e", "@images/ansible/extra-vars.yml", "-e", "ansible_python_interpreter=/usr/bin/python3", var.ansible_extra_args]
     }
 
     provisioner "ansible" {
@@ -40,7 +45,7 @@ build {
       playbook_file = "images/ansible/controller-setup.yml"
       user = "rhel"
       inventory_file_template = "controller ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }}\n"
-      extra_arguments = [ "-e", "@images/ansible/extra-vars.yml" ]
-    }
+      extra_arguments = ["-e", "@images/ansible/extra-vars.yml", "-e", "ansible_python_interpreter=/usr/bin/python3", var.ansible_extra_args]
 
+    }
 }


### PR DESCRIPTION
### Summary
Added an Ansible variable to use Python3 by default during the Packer build process to Ansible and Controller Packer files
- ```"-e", "ansible_python_interpreter=/usr/bin/python3",```

Added an extra Packer variable to Ansible and Controller Pqacke files to enable adding extra Ansible arguments during provisioning. This will be used later when decoupling the `extra-vars.yml` from the base repo
- `var.ansible_extra_args`
- As an example. This can be added to the packer build command
  - ```ansible_extra_args="-e @extra-vars.yml -vvvv -e foo=bar"```

Added `image_name` and `zone` to the Ansible Packer file. This makes debugging and testing easier