### PR TITLE
Cleanup unnecessary artifacts on Instruqt images

### DIFF
--- a/images/ansible/ansible-setup.yml
+++ b/images/ansible/ansible-setup.yml
@@ -128,31 +128,6 @@
       tags:
         - image-cleanup
 
-    # # Stop dnf auto updates
-    # - name: disable dnf automatic services
-    #   ansible.builtin.service:
-    #     name: "{{ item }}"
-    #     state: stopped
-    #   loop:
-    #     - dnf-automatic.timer
-
-    # - name: automatic.conf disable downloads
-    #   ansible.builtin.lineinfile:
-    #     path: /etc/dnf/automatic.conf
-    #     regexp: '^download_updates'
-    #     line: download_updates = no
-
-    # - name: automatic.conf disable updates
-    #   ansible.builtin.lineinfile:
-    #     path: /etc/dnf/automatic.conf
-    #     regexp: '^apply_updates'
-    #     line: apply_updates = no
-
-    # - name: Disable RHUI repos
-    #   ansible.builtin.command: >
-    #     dnf config-manager --set-disabled rhui*
-
-
     ## Execution environments
 - name: Pull EEs in rhel user
   hosts: all

--- a/images/ansible/ansible-setup.yml
+++ b/images/ansible/ansible-setup.yml
@@ -19,8 +19,9 @@
   hosts: all
   become: true
   vars:
-    - admin_password: 'ansible123!'
-
+    admin_password: 'ansible123!'
+    aap_dir: "/home/{{ username }}/aap_install"
+    username: "{{ ansible_user }}"
   tasks:
 
 #    - name: Install useful packages
@@ -118,30 +119,38 @@
     #   package:
     #     name: dnf-automatic
     #     state: absent
-   
-    # Stop dnf auto updates
-    - name: disable dnf automatic services
-      ansible.builtin.service:
-        name: "{{ item }}"
-        state: stopped
-      loop:
-        - dnf-automatic.timer
+    - name: Include common image cleanup tasks
+      ansible.builtin.include_tasks:
+        file: "{{ playbook_dir }}/common/10_image_cleanup.yml"
+        apply:
+          tags: 
+            - image-cleanup
+      tags:
+        - image-cleanup
 
-    - name: automatic.conf disable downloads
-      ansible.builtin.lineinfile:
-        path: /etc/dnf/automatic.conf
-        regexp: '^download_updates'
-        line: download_updates = no
+    # # Stop dnf auto updates
+    # - name: disable dnf automatic services
+    #   ansible.builtin.service:
+    #     name: "{{ item }}"
+    #     state: stopped
+    #   loop:
+    #     - dnf-automatic.timer
 
-    - name: automatic.conf disable updates
-      ansible.builtin.lineinfile:
-        path: /etc/dnf/automatic.conf
-        regexp: '^apply_updates'
-        line: apply_updates = no
+    # - name: automatic.conf disable downloads
+    #   ansible.builtin.lineinfile:
+    #     path: /etc/dnf/automatic.conf
+    #     regexp: '^download_updates'
+    #     line: download_updates = no
 
-    - name: Disable RHUI repos
-      ansible.builtin.command: >
-        dnf config-manager --set-disabled rhui*
+    # - name: automatic.conf disable updates
+    #   ansible.builtin.lineinfile:
+    #     path: /etc/dnf/automatic.conf
+    #     regexp: '^apply_updates'
+    #     line: apply_updates = no
+
+    # - name: Disable RHUI repos
+    #   ansible.builtin.command: >
+    #     dnf config-manager --set-disabled rhui*
 
 
     ## Execution environments

--- a/images/ansible/common/10_image_cleanup.yml
+++ b/images/ansible/common/10_image_cleanup.yml
@@ -48,11 +48,7 @@
   ansible.builtin.file:
     path: "/home/{{ ansible_user }}/.bash_history"
     state: absent
-  tags: 
-    - cleanup-history
 
 - name: Clear bash history
   ansible.builtin.shell: history -c; history -w
-  tags: 
-    - cleanup-history
   

--- a/images/ansible/common/10_image_cleanup.yml
+++ b/images/ansible/common/10_image_cleanup.yml
@@ -1,0 +1,58 @@
+- name: Gather current standard users
+  ansible.builtin.shell: >
+    cut -d: -f1,3 /etc/passwd | egrep ':[0-9]{4}$' | cut -d: -f1
+  register: _standard_users
+  
+- name: Remove all normal users except rhel and awx
+  ansible.builtin.user:
+    name: "{{ item }}"
+    state: absent
+    remove: true
+  loop: "{{ _standard_users.stdout_lines }}"
+  when: 
+    - item != "rhel"
+    - item != "awx"
+    
+- name: disable dnf automatic services
+  ansible.builtin.service:
+    name: "dnf-automatic.timer"
+    state: stopped
+
+- name: automatic.conf disable downloads
+  ansible.builtin.lineinfile:
+    path: /etc/dnf/automatic.conf
+    regexp: '^download_updates'
+    line: download_updates = no
+
+- name: automatic.conf disable updates
+  ansible.builtin.lineinfile:
+    path: /etc/dnf/automatic.conf
+    regexp: '^apply_updates'
+    line: apply_updates = no
+
+- name: Disable RHUI repos
+  ansible.builtin.command: >
+    dnf config-manager --set-disabled rhui*
+
+- name: remove AAP repo
+  ansible.builtin.yum_repository:
+    name: aap_installer
+    state: absent
+
+- name: remove AAP install dir
+  file:
+    path: "{{ aap_dir }}"
+    state: absent
+
+- name: Remove bash history file
+  ansible.builtin.file:
+    path: "/home/{{ ansible_user }}/.bash_history"
+    state: absent
+  tags: 
+    - cleanup-history
+
+- name: Clear bash history
+  ansible.builtin.shell: history -c; history -w
+  tags: 
+    - cleanup-history
+  

--- a/images/ansible/controller-setup.yml
+++ b/images/ansible/controller-setup.yml
@@ -19,9 +19,10 @@
   become: true
   vars:
     admin_password: ansible123!
+    aap_dir: "/home/{{ username }}/aap_install"
+    username: "{{ ansible_user }}"
 
   tasks:
-
     - name: Configure user 'rhel'
       ansible.builtin.user:
         name: rhel
@@ -45,7 +46,6 @@
 
     - name: install automation controller
       vars:
-        username: "{{ ansible_user }}"
         controllerinstall: "true"
       include_role:
         name: ansible.workshops.control_node
@@ -61,33 +61,12 @@
         - /var/lib/ansible-automation-platform-bundle/automation-controller-cli-4.1.1-2.el8ap.x86_64.rpm
 
     - name: install code server
-      vars:
-        username: "{{ ansible_user }}"
       include_role:
         name: ansible.workshops.code_server
 
-    - name: disable dnf automatic services
-      ansible.builtin.service:
-        name: "{{ item }}"
-        state: stopped
-      loop:
-        - dnf-automatic.timer
-
-    - name: automatic.conf disable downloads
-      ansible.builtin.lineinfile:
-        path: /etc/dnf/automatic.conf
-        regexp: '^download_updates'
-        line: download_updates = no
-
-    - name: automatic.conf disable updates
-      ansible.builtin.lineinfile:
-        path: /etc/dnf/automatic.conf
-        regexp: '^apply_updates'
-        line: apply_updates = no
-
-    - name: Disable RHUI repos
-      ansible.builtin.command: >
-        dnf config-manager --set-disabled rhui*
+    - name: Include common image cleanup tasks
+      ansible.builtin.include_tasks:
+        file: "{{ playbook_dir }}/common/10_image_cleanup.yml"
 
     - name: copy setup-scripts to tower node
       copy:


### PR DESCRIPTION
### Summary
- Remove unnecessary users, flies and bash history from Instruqt images.
- Added necessary vars to playbooks for the cleanup tasks:
  - `aap_dir: "/home/{{ username }}/aap_install"`
  -` username: "{{ ansible_user }}"`
- Conslidate repeated vars to the top of the plays

#### Users
Ensure only `rhel` and `awx` users exist on images
#### AAP Install files
Remove the AAP install directory, TAR file and AAP repo to limit exposing code to users without Customer Portal access
#### Bash history
Remove bash history for the RHEL user
#### DNF Updates
Previous tasks to disable Instruqt image updates consolidated to ```images/ansible/common/10_image_cleanup.yml```