### PR TITLE
fix documentation typos

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -4,7 +4,7 @@ Here we document how to reuse existing containers within the Instruqt environmen
 
 ## Gitea
 
-Refer ot the [Gitea Configuration Cheat Sheet](https://docs.gitea.io/en-us/config-cheat-sheet/) for full environment variable options.
+Refer to the [Gitea Configuration Cheat Sheet](https://docs.gitea.io/en-us/config-cheat-sheet/) for full environment variable options.
 ### Environment configuration
 
 - Name: `gitea` or custom choice
@@ -20,7 +20,7 @@ Refer ot the [Gitea Configuration Cheat Sheet](https://docs.gitea.io/en-us/confi
   - `GITEA__security__INSTALL_LOCK`: `true`
   - `GITEA__server__SSH_LISTEN_PORT`: `2222`
 
-### Gitea user and repo configuraiton variables
+### Gitea user and repo configuration variables
 
 - Environment Variables:
   - `GITEA__repository__DEFAULT_PUSH_CREATE_PRIVATE: false`

--- a/images/README.md
+++ b/images/README.md
@@ -81,7 +81,7 @@ The `ansible_vars_file` packer variable enables you to specify a file with addit
 >**Note**<p>
 > Your `extra_vars.yml` file contains sensitive information.<p>
 > Ensure it's safe and excluded from repository pull requests and commits.<p>
-### Example `extra_vars.yml` file**
+### Example `extra_vars.yml` file
 
 ```
 # Extra vars example file for Instruqt automation mesh images
@@ -111,6 +111,8 @@ which is an offline token to download AAP from access.redhat.com.  This uses the
 
 This is a license file to apply to AAP.  Please refer to this video by Colin McNaughton [https://www.youtube.com/watch?v=FYtilnsk7sM](https://www.youtube.com/watch?v=FYtilnsk7sM) to figure out how to get your manifest.zip
 
+Place the `manifest.zip` in the `images\ansible` folder.
+
 To execute packer run the following command->
 
 ```packer build --force automation-controller.pkr.hcl```
@@ -135,7 +137,6 @@ The steps below create the following GCP images:
 
 This is a license file to apply to AAP.  Please refer to this video by Colin McNaughton [https://www.youtube.com/watch?v=FYtilnsk7sM](https://www.youtube.com/watch?v=FYtilnsk7sM) to figure out how to get your manifest.zip
 
-Place the `manifest.zip` in the `images\ansible` folder.
 
 **Required extra variables**
 


### PR DESCRIPTION
#### Summary
- Fixed placement of `manifest.zip` instructions to build automation controller image
- Fixed typos on Gitea container instructions