### PR TITLE
removing navigator installed by pip

### DIFF
--- a/images/ansible/controller-setup.yml
+++ b/images/ansible/controller-setup.yml
@@ -61,7 +61,6 @@
         name:
           - python-jenkins
           - jmespath
-          - ansible-navigator
         state: present
       become: true
   


### PR DESCRIPTION
Installing navigator via pip installs version 1.1 which is not what we want. We want version 2.x