### PR TITLE
Enhance the instructions in the inventory challenge.

### DIFF
--- a/tracks/getting-started-controller/02-inventory/assignment.md
+++ b/tracks/getting-started-controller/02-inventory/assignment.md
@@ -60,26 +60,36 @@ These machines are configured to be able to `ssh` to each other using an ssh key
 All tasks are performed in the automation controller dashboard
 * On the side navigation under the **Resources** section, click on **Inventories**
 * Under **Inventories**, click on **Add**
-* Create a new Inventory called `Lab-Inventory`
+* Click **Add inventory**.
+* Create a new Inventory with the name `Lab-Inventory`. Leave all the other fields as-is, and click **Save**.
 ![inventory](https://raw.githubusercontent.com/craig-br/instruqt-tracks/devel/assets/controller/controller-inventory.png)
 ***
 <br>
 
-* Once you've created the `Lab-Inventory`, click on **Hosts**
-* Add the two hosts `host01` and `host02` to the `Lab-Inventory`
+Once you've created the `Lab-Inventory`, click on **Hosts*
+
+* Click on "Add".
+* Enter the name `host01` in the **Name** text box. Leave everything else the same, then click **Save**.
+* Repeat the above steps to create `host02`.
+
 ![hosts](https://raw.githubusercontent.com/craig-br/instruqt-tracks/devel/assets/controller/controller-hosts.png)
+
 ***
 <br>
 
 * Once you've added `host01` and `host02` to the `Lab-Inventory` go back to the Inventory list.
 * Click on `Lab-Inventory` and select **Groups** on the top menu.
-* Create a new group called `web` in the `Lab-Inventory`
+* Click **Add** to create a new group.
+* Create a new group called `web` in the `Lab-Inventory`.
+* Click **Save** when you are finished.
 ![group](https://raw.githubusercontent.com/craig-br/instruqt-tracks/devel/assets/controller/controller-inst-add-group.png)
 ***
 <br>
 
 * Click on the newly created `web` group and click on **Hosts** on the top menu.
-* Add the existing `host01` and `host02` to the `web` group
+* Click **Add existing host**. A pop up will appear.
+* Select both `host01` and `host02`, then click **Save**.
+* `host01` and `host02` are now added to the `web` group.
 ![group](https://raw.githubusercontent.com/craig-br/instruqt-tracks/devel/assets/controller/controller-inst-add-hosts-group.png)
 ***
 <br>


### PR DESCRIPTION
A request for a small enhancement to the assignment in a track - we jump pretty quickly over some steps, so users who are unfamiliar with the UI may wonder what they need to click next. They might also wonder if they have to change any of the other fields on the various screens.

This aims to clarify the process of adding hosts and groups to `Lab-Inventory`.