### PR TITLE
Update CSS remove img width: 100%

### DIFF
--- a/tracks/devops-controller/01-env-overview/assignment.md
+++ b/tracks/devops-controller/01-env-overview/assignment.md
@@ -247,7 +247,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/devops-controller/02-update-pipeline/assignment.md
+++ b/tracks/devops-controller/02-update-pipeline/assignment.md
@@ -234,7 +234,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/devops-controller/03-update-app/assignment.md
+++ b/tracks/devops-controller/03-update-app/assignment.md
@@ -297,7 +297,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/devops-controller/04-controller-approval/assignment.md
+++ b/tracks/devops-controller/04-controller-approval/assignment.md
@@ -356,7 +356,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/devops-controller/05-devops-playground/assignment.md
+++ b/tracks/devops-controller/05-devops-playground/assignment.md
@@ -113,7 +113,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-edge-lab/01-env-overview/assignment.md
+++ b/tracks/getting-started-edge-lab/01-env-overview/assignment.md
@@ -238,7 +238,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-edge-lab/02-install-edge-app/assignment.md
+++ b/tracks/getting-started-edge-lab/02-install-edge-app/assignment.md
@@ -203,7 +203,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-edge-lab/03-install-monitor-app/assignment.md
+++ b/tracks/getting-started-edge-lab/03-install-monitor-app/assignment.md
@@ -177,7 +177,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-edge-lab/04-config-firewall/assignment.md
+++ b/tracks/getting-started-edge-lab/04-config-firewall/assignment.md
@@ -199,7 +199,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-edge-lab/05-edge-workflow/assignment.md
+++ b/tracks/getting-started-edge-lab/05-edge-workflow/assignment.md
@@ -380,7 +380,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-mesh/01-overview/assignment.md
+++ b/tracks/getting-started-mesh/01-overview/assignment.md
@@ -206,7 +206,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-mesh/02-mesh-instance-groups/assignment.md
+++ b/tracks/getting-started-mesh/02-mesh-instance-groups/assignment.md
@@ -198,7 +198,7 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
+
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-mesh/03-multi-site/assignment.md
+++ b/tracks/getting-started-mesh/03-multi-site/assignment.md
@@ -244,7 +244,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-mesh/04-high-availability/assignment.md
+++ b/tracks/getting-started-mesh/04-high-availability/assignment.md
@@ -296,7 +296,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;

--- a/tracks/getting-started-mesh/05-playground/assignment.md
+++ b/tracks/getting-started-mesh/05-playground/assignment.md
@@ -152,7 +152,6 @@ If you have encountered an issue or have noticed something not quite right, plea
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
   }
   h1 {
     font-size: 18px;


### PR DESCRIPTION
#### Summary
Formatting of tabs in labs broke due to custom CSS

- Removed `img{ width: 100%;}` from custom CSS