### PR TITLE
fixing lint issue where ansible-lint was missing

### DIFF
--- a/tracks/writing-first-playbook/track_scripts/setup-control
+++ b/tracks/writing-first-playbook/track_scripts/setup-control
@@ -51,3 +51,5 @@ cat /etc/yum.repos.d/centos8-appstream.repo'
 
 sudo dnf clean all
 sudo dnf install -y ansible-navigator
+sudo dnf install -y ansible-lint
+pip3.9 install yamllint


### PR DESCRIPTION
Currently the writing first playbook instruqt did not have ansible-lint installed and the editor was attempting to use the extension causing ansible-lint failures. This adds the ansible-lint package and the yamllint module to the environment

Fixes: #336 