### PR TITLE
Adding name as part of Motd task

### DIFF
--- a/tracks/writing-first-playbook/11-playbook-templates/assignment.md
+++ b/tracks/writing-first-playbook/11-playbook-templates/assignment.md
@@ -65,7 +65,8 @@ Create an Ansible playbook that uses the newly created template file. Within the
   hosts: node1
   become: true
   tasks:
-    - ansible.builtin.template:
+    - name: Motd Template
+      ansible.builtin.template:
         src: motd-facts.j2
         dest: /etc/motd
         owner: root


### PR DESCRIPTION
The motd task was missing the name portion of the task. Including in this fix.

Fixes: #343 