### PR TITLE
fixing ansible navigator config

### DIFF
--- a/tracks/writing-first-playbook/01-playbook-inventory/setup-control
+++ b/tracks/writing-first-playbook/01-playbook-inventory/setup-control
@@ -9,4 +9,5 @@ git config --global user.name "Red Hat"
 echo "[defaults]" > /home/rhel/.ansible.cfg
 echo "inventory = /home/rhel/ansible-files/hosts" >> /home/rhel/.ansible.cfg
 echo "host_key_checking = False" >> /home/rhel/.ansible.cfg
+cp /home/rhel/ansible-navigator.yml /home/rhel/.ansible-navigator.yml
 mv /home/rhel/ansible-navigator.yml /home/rhel/ansible-files/ansible-navigator.yml


### PR DESCRIPTION
No default ansible-navigator.yml config file was set. Need this in order to ensure the proper EE is set for the writing your first playbook track. 

Fixes: #355 